### PR TITLE
Fix error The return type 'ImageSpan' isn't a 'TextSpan', as defined by the method 'finishText'.

### DIFF
--- a/example/lib/special_text/emoji_text.dart
+++ b/example/lib/special_text/emoji_text.dart
@@ -19,7 +19,8 @@ class EmojiText extends SpecialText {
       ///fontSize 26 and text height =30.0
       //final double fontSize = 26.0;
 
-      return ImageSpan(AssetImage(EmojiUitl.instance.emojiMap[key]),
+      return ImageSpan(
+          AssetImage(EmojiUitl.instance.emojiMap[key]),
           actualText: key,
           imageWidth: size,
           imageHeight: size,


### PR DESCRIPTION
System info:

Dart 2.4.0
Flutter 1.7.8+hotfix.4

https://github.com/fluttercandies/like_button/blob/d38afda7741cad0bc9551a5f5927cfa7f6714a4e/example/lib/special_text/emoji_text.dart#L12

Move to dynamic type:

```dart
@override
finishText() {
```