### PR TITLE
Fix Number reversed when using RTL localization.

### DIFF
--- a/lib/src/like_button.dart
+++ b/lib/src/like_button.dart
@@ -1,7 +1,12 @@
 ///
 ///  create by zmtzawqlp on 2019/5/27
 ///
-
+import 'package:flutter/material.dart';
+import 'package:like_button/src/painter/circle_painter.dart';
+import 'package:like_button/src/painter/bubbles_painter.dart';
+import 'package:like_button/src/utils/like_button_model.dart';
+import 'package:like_button/src/utils/like_button_typedef.dart';
+import 'package:like_button/src/utils/like_button_util.dart';
 class LikeButton extends StatefulWidget {
   const LikeButton(
       {Key? key,

--- a/lib/src/like_button.dart
+++ b/lib/src/like_button.dart
@@ -2,13 +2,6 @@
 ///  create by zmtzawqlp on 2019/5/27
 ///
 
-import 'package:flutter/material.dart';
-import 'package:like_button/src/painter/circle_painter.dart';
-import 'package:like_button/src/painter/bubbles_painter.dart';
-import 'package:like_button/src/utils/like_button_model.dart';
-import 'package:like_button/src/utils/like_button_typedef.dart';
-import 'package:like_button/src/utils/like_button_util.dart';
-
 class LikeButton extends StatefulWidget {
   const LikeButton(
       {Key? key,
@@ -310,41 +303,44 @@ class LikeButtonState extends State<LikeButton> with TickerProviderStateMixin {
       result = AnimatedBuilder(
           animation: _likeCountController!,
           builder: (BuildContext b, Widget? w) {
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Stack(
-                  fit: StackFit.passthrough,
-                  clipBehavior: Clip.hardEdge,
-                  children: <Widget>[
-                    Opacity(
-                      child: currentSameWidget,
-                      opacity: _opacityAnimation.value,
-                    ),
-                    Opacity(
-                      child: preSameWidget,
-                      opacity: 1.0 - _opacityAnimation.value,
-                    ),
-                  ],
-                ),
-                Stack(
-                  fit: StackFit.passthrough,
-                  clipBehavior: Clip.hardEdge,
-                  children: <Widget>[
-                    FractionalTranslation(
-                        translation: _preLikeCount! > _likeCount!
-                            ? _slideCurrentValueAnimation.value
-                            : -_slideCurrentValueAnimation.value,
-                        child: currentWidget),
-                    FractionalTranslation(
-                        translation: _preLikeCount! > _likeCount!
-                            ? _slidePreValueAnimation.value
-                            : -_slidePreValueAnimation.value,
-                        child: preWidget),
-                  ],
-                )
-              ],
+            return Directionality(
+              textDirection: TextDirection.ltr,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  Stack(
+                    fit: StackFit.passthrough,
+                    clipBehavior: Clip.hardEdge,
+                    children: <Widget>[
+                      Opacity(
+                        child: currentSameWidget,
+                        opacity: _opacityAnimation.value,
+                      ),
+                      Opacity(
+                        child: preSameWidget,
+                        opacity: 1.0 - _opacityAnimation.value,
+                      ),
+                    ],
+                  ),
+                  Stack(
+                    fit: StackFit.passthrough,
+                    clipBehavior: Clip.hardEdge,
+                    children: <Widget>[
+                      FractionalTranslation(
+                          translation: _preLikeCount! > _likeCount!
+                              ? _slideCurrentValueAnimation.value
+                              : -_slideCurrentValueAnimation.value,
+                          child: currentWidget),
+                      FractionalTranslation(
+                          translation: _preLikeCount! > _likeCount!
+                              ? _slidePreValueAnimation.value
+                              : -_slidePreValueAnimation.value,
+                          child: preWidget),
+                    ],
+                  )
+                ],
+              ),
             );
           });
     } else {


### PR DESCRIPTION
#### :information_source: Number always writen from Left to Right it does not matter if the text direction is RTL or LTR.
### :bug: Bug:
- when using a RTL localization the number appears reversed, for example if you have `count=24` It Will appear as `42` and when you press the button it will go to `52` .
### :dart: Reason:
- When using an Arabic Localization for examples, Flutter will automatically reverse Row items so the first item will be the last.
### :gear: Fix:
- To fix this you need to force the row of numbers to use LTR by adding `Directionality`