### PR TITLE
Fix _handleIsLikeChanged which stops animations when a remote initial value of isLiked is provided to LikeButton

### DIFF
--- a/lib/src/like_button.dart
+++ b/lib/src/like_button.dart
@@ -447,7 +447,7 @@ class LikeButtonState extends State<LikeButton> with TickerProviderStateMixin {
       return;
     }
 
-    if (isLiked != null && isLiked != _isLiked) {
+    if (isLiked != null ) {
       if (_likeCount != null) {
         _preLikeCount = _likeCount;
         if (isLiked) {
@@ -456,7 +456,10 @@ class LikeButtonState extends State<LikeButton> with TickerProviderStateMixin {
           _likeCount = _likeCount! - 1;
         }
       }
-      _isLiked = isLiked;
+      setState((){
+        _isLiked = isLiked;
+      });
+
 
       if (mounted) {
         setState(() {


### PR DESCRIPTION
Fix _handleIsLikeChanged which stops animations when a remote initial value (eg: from Firestore) of isLiked is provided to LikeButton. The comparison isLiked != _isLiked is unnecessary